### PR TITLE
자녀 선택 정보 전역 상태 관리 및 해설/기록 연동

### DIFF
--- a/app/users/components/AnalysisCard.tsx
+++ b/app/users/components/AnalysisCard.tsx
@@ -18,77 +18,63 @@ const ITEMS_PER_PAGE = 5;
 
 export function AnalysisCard() {
   const selectedChild = useSelectedChildStore((state) => state.selectedChild);
-
-  const [allLogs, setAllLogs] = useState<AnalysisResultItem[]>([]);
-  const [visibleLogs, setVisibleLogs] = useState<AnalysisResultItem[]>([]);
-  const [error, setError] = useState<string | null>(null);
+  const [logs, setLogs] = useState<AnalysisResultItem[]>([]);
+  const [page, setPage] = useState(0);
+  const [hasMore, setHasMore] = useState(true);
   const [loading, setLoading] = useState(false);
-  const [isInitialLoading, setIsInitialLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const { ref, inView } = useInView();
 
-  const fetchLogs = async () => {
+  const fetchLogs = async (page: number) => {
     try {
       if (!selectedChild) {
         setError('자녀를 먼저 선택해주세요.');
-        setIsInitialLoading(false);
         return;
       }
 
-      const token = localStorage.getItem('accessToken');
-      if (!token) {
-        setError('로그인이 필요합니다.');
-        setIsInitialLoading(false);
-        return;
-      }
-
+      setLoading(true);
       const res = await authorizedFetch(
-        `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/math/logs?userJrId=${selectedChild.id}`,
+        `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/math/logs?userJrId=${selectedChild.id}&page=${page}&size=${ITEMS_PER_PAGE}`
       );
       if (!res.ok) throw new Error(`요청 실패: ${res.status}`);
 
-      const data = await res.json();
-      const logs: AnalysisResultItem[] = data.logs;
 
-      setAllLogs(logs);
-      setVisibleLogs(logs.slice(0, ITEMS_PER_PAGE));
+      const data = await res.json();
+      const newLogs: AnalysisResultItem[] = data.logs;
+
+      setLogs((prev) => [...prev, ...newLogs]);
+      setHasMore(newLogs.length === ITEMS_PER_PAGE);
     } catch (err) {
       setError(err instanceof Error ? err.message : '데이터를 불러오지 못했습니다.');
     } finally {
-      setIsInitialLoading(false);
+      setLoading(false);
     }
   };
 
   useEffect(() => {
-    fetchLogs();
-  }, [selectedChild]); 
+    setLogs([]);
+    setPage(0);
+    setHasMore(true);
+    setError(null);
+    if (selectedChild) {
+      fetchLogs(0);
+    }
+  }, [selectedChild]);
 
   useEffect(() => {
-    if (inView && !loading && visibleLogs.length < allLogs.length) {
-      setLoading(true);
-      setTimeout(() => {
-        const nextItems = allLogs.slice(
-          visibleLogs.length,
-          visibleLogs.length + ITEMS_PER_PAGE
-        );
-        setVisibleLogs(prev => [...prev, ...nextItems]);
-        setLoading(false);
-      }, 600);
+    if (inView && !loading && hasMore) {
+      fetchLogs(page + 1);
+      setPage((prev) => prev + 1);
     }
-  }, [inView, loading, visibleLogs, allLogs]);
+  }, [inView]);
 
   if (error) return <p className="text-sm text-red-500">{error}</p>;
-
-  if (isInitialLoading) {
-    return <ListCardSkeleton count={ITEMS_PER_PAGE} />;
-  }
-
-  if (!allLogs.length) {
-    return <p className="text-sm text-gray-500">분석 기록이 없습니다.</p>;
-  }
+  if (!logs.length && loading) return <ListCardSkeleton count={ITEMS_PER_PAGE} />;
+  if (!logs.length) return <p className="text-sm text-gray-500">분석 기록이 없습니다.</p>;
 
   return (
     <div className="flex flex-col gap-2.5">
-      {visibleLogs.map(item => (
+      {logs.map((item) => (
         <ListCard
           key={item.logSolveId}
           id={item.logSolveId}
@@ -104,7 +90,7 @@ export function AnalysisCard() {
         </div>
       )}
 
-      {visibleLogs.length < allLogs.length && <div ref={ref} className="h-6" />}
+      {hasMore && <div ref={ref} className="h-6" />}
     </div>
   );
 }

--- a/app/users/page.tsx
+++ b/app/users/page.tsx
@@ -10,6 +10,7 @@ import { AnalysisCard } from './components/AnalysisCard';
 import { WithdrawButton } from './components/WithdrawButton';
 
 import { useUserStore } from '@/lib/store/useUserStore';
+import { useSelectedChildStore } from '@/lib/store/useSelectedChildStore';
 import { authorizedFetch } from '@/lib/authorizedFetch';
 
 interface Child {
@@ -28,6 +29,7 @@ export default function UsersPage() {
 
   const setUser = useUserStore((state) => state.setUser);
   const clearUser = useUserStore((state) => state.clearUser);
+  const setSelectedChild = useSelectedChildStore((state) => state.setSelectedChild);
 
   useEffect(() => {
     const token = localStorage.getItem('accessToken');
@@ -65,14 +67,27 @@ export default function UsersPage() {
     fetchUserInfo();
   }, [router, setUser, clearUser]);
 
+  useEffect(() => {
+    if (children.length > 0) {
+      setSelectedChild(children[0]);
+    }
+  }, [children, setSelectedChild]);
+  
+
   const handleChildDeleted = (deletedId: number) => {
     const updatedChildren = children.filter((c) => c.id !== deletedId);
     setChildren(updatedChildren);
 
     if (children[selectedIndex]?.id === deletedId) {
-      setSelectedIndex(0);
+      const newIndex = 0;
+      setSelectedIndex(newIndex);
+      if (updatedChildren.length > 0) {
+        setSelectedChild(updatedChildren[newIndex]);
+      }
     } else if (selectedIndex >= updatedChildren.length) {
-      setSelectedIndex(updatedChildren.length - 1);
+      const newIndex = updatedChildren.length - 1;
+      setSelectedIndex(newIndex);
+      setSelectedChild(updatedChildren[newIndex]);
     }
   };
 
@@ -96,7 +111,10 @@ export default function UsersPage() {
                 profileImageId={child.profileImageId}
                 parentId={child.parentId}
                 selected={selectedIndex === index}
-                onClick={() => setSelectedIndex(index)}
+                onClick={() => {
+                  setSelectedIndex(index);
+                  setSelectedChild(child);
+                }}
                 onDeleted={() => handleChildDeleted(child.id)}
               />
             ))}

--- a/lib/store/useSelectedChildStore.ts
+++ b/lib/store/useSelectedChildStore.ts
@@ -1,0 +1,29 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+type SelectedChild = {
+  id: number;
+  name: string;
+  grade: number;
+  profileImageId: number | null;
+  parentId: number;
+};
+
+interface SelectedChildState {
+  selectedChild: SelectedChild | null;
+  setSelectedChild: (child: SelectedChild) => void;
+  clearSelectedChild: () => void;
+}
+
+export const useSelectedChildStore = create(
+  persist<SelectedChildState>(
+    (set) => ({
+      selectedChild: null,
+      setSelectedChild: (child) => set({ selectedChild: child }),
+      clearSelectedChild: () => set({ selectedChild: null }),
+    }),
+    {
+      name: 'selected-child',
+    }
+  )
+);

--- a/lib/store/useSelectedChildStore.ts
+++ b/lib/store/useSelectedChildStore.ts
@@ -5,8 +5,8 @@ type SelectedChild = {
   id: number;
   name: string;
   schoolGrade: number;
-  profileImageId: number | null;
   parentId: number;
+  profileImageUrl?: string | null;
 };
 
 interface SelectedChildState {

--- a/lib/store/useSelectedChildStore.ts
+++ b/lib/store/useSelectedChildStore.ts
@@ -4,7 +4,7 @@ import { persist } from 'zustand/middleware';
 type SelectedChild = {
   id: number;
   name: string;
-  grade: number;
+  schoolGrade: number;
   profileImageId: number | null;
   parentId: number;
 };


### PR DESCRIPTION
## 📌 이슈 번호
Closes #57 

## ✨ 작업 내용

- 마이페이지에서 선택 된 자녀의 정보를 persist를 사용해서 전역 상태 관리
- 선택 된 자녀만의 이전 분석 기록을 보여줌

## ✅ 체크리스트

- [ ] 코드가 정상적으로 동작하는지 확인했습니다.
- [ ] 관련된 테스트를 추가하거나 수정했습니다.
- [ ] 문서화가 필요한 경우 문서를 업데이트했습니다.

## 📸 스크린샷(선택)
<img width="1425" height="706" alt="image" src="https://github.com/user-attachments/assets/bced2772-4503-47f8-a264-b1f0efb9c4a9" />

## 💬 기타 참고 사항
