### PR TITLE
로그인/회원 관리 API 리팩토링

### DIFF
--- a/app/components/AnalysisResult.tsx
+++ b/app/components/AnalysisResult.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { ListCard } from '@/components/ui/listcard';
 import { ListCardSkeleton } from '@/components/common/ListCardSkeleton';
 import Link from 'next/link';
+import { authorizedFetch } from '@/lib/authorizedFetch';
 
 interface AnalysisResultItem {
   logSolveId: number;
@@ -29,13 +30,10 @@ export function AnalysisResult() {
       }
 
       try {
-        const res = await fetch(
+        const res = await authorizedFetch(
           `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/math/logs?page=0&size=3&userJrId=${storedData}`,
           {
             method: 'GET',
-            headers: {
-              Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
-            },
           },
         );
         if (!res.ok) {

--- a/app/users/components/LogoutButton.tsx
+++ b/app/users/components/LogoutButton.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useUserStore } from '@/stores/useUserStore';
+import { toast } from 'sonner';
+import { authorizedFetch } from '@/lib/authorizedFetch';
+
+export function LogoutButton() {
+  const router = useRouter();
+  const clearUser = useUserStore((state) => state.clearUser);
+
+  const handleLogout = async () => {
+    try {
+      const res = await authorizedFetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/users/logout`, {
+        method: 'POST'
+      });
+
+      if (!res.ok) throw new Error('로그아웃 실패');
+
+      localStorage.removeItem('accessToken');
+      clearUser();
+      toast.success('로그아웃 되었습니다.');
+      router.push('/login');
+    } catch (err) {
+      console.error('로그아웃 오류:', err);
+      toast.error('로그아웃에 실패했습니다.');
+    }
+  };
+
+  return (
+    <button onClick={handleLogout} className='cursor-pointer'>
+      로그아웃
+    </button>
+  );
+}

--- a/app/users/components/LogoutButton.tsx
+++ b/app/users/components/LogoutButton.tsx
@@ -12,13 +12,16 @@ export function LogoutButton() {
   const handleLogout = async () => {
     try {
       const res = await authorizedFetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/users/logout`, {
-        method: 'POST'
+        method: 'POST',
       });
 
       if (!res.ok) throw new Error('로그아웃 실패');
 
       localStorage.removeItem('accessToken');
+      localStorage.removeItem('selected-child'); 
       clearUser();
+      localStorage.removeItem('user-store');
+
       toast.success('로그아웃 되었습니다.');
       router.push('/login');
     } catch (err) {
@@ -28,7 +31,7 @@ export function LogoutButton() {
   };
 
   return (
-    <button onClick={handleLogout} className='cursor-pointer'>
+    <button onClick={handleLogout} className="cursor-pointer">
       로그아웃
     </button>
   );

--- a/app/users/components/WithdrawButton.tsx
+++ b/app/users/components/WithdrawButton.tsx
@@ -24,7 +24,10 @@ export function WithdrawButton() {
       if (!res.ok) throw new Error('회원 탈퇴 실패');
 
       localStorage.removeItem('accessToken');
+      localStorage.removeItem('selected-child'); 
       clearUser();
+      localStorage.removeItem('user-store');
+
       toast.success('회원 탈퇴가 완료되었습니다.');
       router.push('/login');
     } catch (err) {

--- a/app/users/components/WithdrawButton.tsx
+++ b/app/users/components/WithdrawButton.tsx
@@ -37,7 +37,7 @@ export function WithdrawButton() {
 
   return (
     <>
-      <button onClick={handleOpen}>회원탈퇴</button>
+      <button onClick={handleOpen} className='cursor-pointer'>회원탈퇴</button>
       <ConfirmModal
         open={open}
         onClose={handleClose}

--- a/app/users/components/WithdrawButton.tsx
+++ b/app/users/components/WithdrawButton.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { ConfirmModal } from '@/components/common/ConfirmModal';
 import { useUserStore } from '@/stores/useUserStore';
 import { toast } from 'sonner';
+import { authorizedFetch } from '@/lib/authorizedFetch';
 
 export function WithdrawButton() {
   const [open, setOpen] = useState(false);
@@ -16,12 +17,8 @@ export function WithdrawButton() {
 
   const handleWithdraw = async () => {
     try {
-      const res = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/users/me`, {
-        method: 'DELETE',
-        credentials: 'include',
-        headers: {
-          Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
-        },
+      const res = await authorizedFetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/users`, {
+        method: 'DELETE'
       });
 
       if (!res.ok) throw new Error('회원 탈퇴 실패');

--- a/app/users/page.tsx
+++ b/app/users/page.tsx
@@ -16,6 +16,7 @@ import { EmptyChildCard } from './components/EmptyChild';
 import { AnalysisCard } from './components/AnalysisCard';
 import { WithdrawButton } from './components/WithdrawButton';
 import { ChildCardSkeleton } from './components/ui/ChildCardSkeleton';
+import { LogoutButton } from './components/LogoutButton';
 
 interface Child {
   id: number;
@@ -150,16 +151,8 @@ export default function UsersPage() {
       <h2 className="text-lg font-semibold mb-6">이전 분석 기록</h2>
       <AnalysisCard />
 
-      <div className="flex flex-col items-start gap-4 mt-10 text-sm text-gray-300 cursor-pointer">
-        <button
-          onClick={() => {
-            localStorage.removeItem('accessToken');
-            clearUser();
-            router.push('/login');
-          }}
-        >
-          로그아웃
-        </button>
+      <div className="flex flex-col items-start gap-4 mt-10 text-sm text-gray-300">
+        <LogoutButton />
         <WithdrawButton />
       </div>
     </div>

--- a/app/users/page.tsx
+++ b/app/users/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 
-import { useUserStore } from '@/stores/useUserStore';
 import { useSelectedChildStore } from '@/stores/useSelectedChildStore';
 import { authorizedFetch } from '@/lib/authorizedFetch';
 
@@ -32,8 +31,6 @@ export default function UsersPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [children, setChildren] = useState<Child[]>([]);
 
-  const setUser = useUserStore((state) => state.setUser);
-  const clearUser = useUserStore((state) => state.clearUser);
   const { setSelectedChild } = useSelectedChildStore();
 
   const {
@@ -45,22 +42,14 @@ export default function UsersPage() {
   useEffect(() => {
     if (authLoading) return;
 
-    const fetchUserInfo = async () => {
+    const fetchChildren = async () => {
       try {
         const res = await authorizedFetch(
-          `${process.env.NEXT_PUBLIC_BACKEND_URL}/test/api/temp/user/me`
-        );
-        if (!res.ok) throw new Error(`사용자 정보 응답 실패: ${res.status}`);
-
-        const userData = await res.json();
-        setUser(userData);
-
-        const childrenRes = await authorizedFetch(
           `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/user-jrs/parent`
         );
-        if (!childrenRes.ok) throw new Error('자녀 정보 조회 실패');
+        if (!res.ok) throw new Error('자녀 정보 조회 실패');
 
-        const childList: Child[] = await childrenRes.json();
+        const childList: Child[] = await res.json();
         setChildren(childList);
 
         if (childList.length > 0) {
@@ -73,15 +62,14 @@ export default function UsersPage() {
 
         setIsLoading(false);
       } catch (error) {
-        console.error('인증 또는 자녀 조회 실패:', error);
+        console.error('자녀 조회 실패:', error);
         localStorage.removeItem('accessToken');
-        clearUser();
         router.replace('/login');
       }
     };
 
-    fetchUserInfo();
-  }, [authLoading, router, setUser, clearUser, setSelectedChild]);
+    fetchChildren();
+  }, [authLoading, router, setSelectedChild]);
 
   const handleChildDeleted = (deletedId: number) => {
     const updatedChildren = children.filter((c) => c.id !== deletedId);

--- a/stores/useUserStore.ts
+++ b/stores/useUserStore.ts
@@ -3,7 +3,6 @@ import { persist } from 'zustand/middleware';
 
 interface User {
   userId: number;
-  name: string;
 }
 
 interface UserState {
@@ -21,7 +20,9 @@ export const useUserStore = create<UserState>()(
     }),
     {
       name: 'user-store',
-      partialize: (state) => ({ user: state.user }), 
+      partialize: (state) => ({
+        user: state.user ? { userId: state.user.userId } : null,
+      }),
     }
   )
 );

--- a/stores/useUserStore.ts
+++ b/stores/useUserStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
 interface User {
   userId: number;
@@ -11,8 +12,16 @@ interface UserState {
   clearUser: () => void;
 }
 
-export const useUserStore = create<UserState>((set) => ({
-  user: null,
-  setUser: (user) => set({ user }),
-  clearUser: () => set({ user: null }),
-}));
+export const useUserStore = create<UserState>()(
+  persist(
+    (set) => ({
+      user: null,
+      setUser: (user) => set({ user }),
+      clearUser: () => set({ user: null }),
+    }),
+    {
+      name: 'user-store',
+      partialize: (state) => ({ user: state.user }), 
+    }
+  )
+);


### PR DESCRIPTION
## 📌 이슈 번호
Closes #84 

## ✨ 작업 내용

- 로그아웃 API 연동
- 회원 탈퇴 API 수정
- 마이페이지 로그인 관련 (/test/me) api 삭제 
- user store 수정
- 메인 페이지, 회원 탈퇴  analysis result -> authorizedFetch 사용

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [ ] 관련된 테스트를 추가하거나 수정했습니다.
- [ ] 문서화가 필요한 경우 문서를 업데이트했습니다.

## 📸 스크린샷(선택)

## 💬 기타 참고 사항
