### PR TITLE
헤더 렌더링 및 자녀 선택 상태 오류 수정

### DIFF
--- a/app/users/components/ChildCard.tsx
+++ b/app/users/components/ChildCard.tsx
@@ -50,6 +50,7 @@ export function ChildCard({
       if (!res.ok) throw new Error('자녀 삭제 실패');
 
       toast.success(`${name} 프로필이 삭제되었습니다.`);
+      localStorage.removeItem('selected-child');
       setShowModal(false);
       onDeleted?.(id);
     } catch (err) {

--- a/components/common/BodyWrapper.tsx
+++ b/components/common/BodyWrapper.tsx
@@ -15,7 +15,14 @@ export function BodyWrapper({ children }: Props) {
   const pathname = usePathname();
   const { isDataLoading } = useLoadingStore();
 
-  const currentPageConfig = pagesConfig[pathname as keyof typeof pagesConfig] || {
+    const normalizePath = (path: string): string => {
+    if (path.startsWith('/users/edit/')) return '/users/edit/[id]';
+    return path;
+  };
+
+  const matchedPath = normalizePath(pathname);
+
+  const currentPageConfig = pagesConfig[matchedPath as keyof typeof pagesConfig] || {
     headerType: 'secondary',
     showFooter: false,
   };

--- a/config/pagesConfig.ts
+++ b/config/pagesConfig.ts
@@ -11,6 +11,14 @@ export const pagesConfig = {
     headerType: 'primary',
     showFooter: true,
   },
+  '/users/register-child': {
+    headerType: 'primary', 
+    showFooter: false,
+  },
+  '/users/edit/[id]': {
+    headerType: 'primary', 
+    showFooter: false,
+  },
   '/result': {
     headerType: 'secondary',
     showFooter: true,


### PR DESCRIPTION
## 📌 이슈 번호
Closes #106 

## ✨ 작업 내용

- 자녀 등록 / 수정 페이지 헤더 수정
- 자녀가 모두 삭제됨에도 local에 child-select가 남아 있는 오류 수정

## ✅ 체크리스트

- [ ] 코드가 정상적으로 동작하는지 확인했습니다.
- [ ] 관련된 테스트를 추가하거나 수정했습니다.
- [ ] 문서화가 필요한 경우 문서를 업데이트했습니다.

## 📸 스크린샷(선택)

| 헤더 변경 전 | 헤더 변경 후 |
|------------------|----------------|
| ![헤더 변경 전](https://github.com/user-attachments/assets/7985d9fd-122f-4a41-a550-8cffcebe61fb) | ![헤더 변경 후](https://github.com/user-attachments/assets/698769d7-df10-4cad-ae61-52f161019eb7) |

## 💬 기타 참고 사항
